### PR TITLE
Added support for CompanionClickTracking property to VAST parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 Complies with [VAST 3.0 spec](http://www.iab.net/media/file/VASTv3.0.pdf).
 
+# Fyber Custom Modifications
+
+At the time of writing, the official client does not support the CompanionClickTracking
+property in VAST companion ad tags
+(see [the VAST spec](http://www.iab.com/wp-content/uploads/2015/06/VASTv3_0.pdf)
+for details). Only a single-line patch in the
+[parser script](https://github.com/SponsorPay/vast-client-js/blob/master/src/parser.coffee#L359)
+was required, so for now this is a custom modification.
+[An issue is open](https://github.com/dailymotion/vast-client-js/issues/107) on
+the main project so it's possible this change can be reverted soon.
+
 ## Build / Contribute
 
 See [CONTRIBUTING](CONTRIBUTING.md)

--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -357,6 +357,7 @@ class VASTParser
                         companionAd.trackingEvents[eventName] ?= []
                         companionAd.trackingEvents[eventName].push trackingURLTemplate
             companionAd.companionClickThroughURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickThrough"))
+            companionAd.companionClickTrackingURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickTracking"))
             creative.variations.push companionAd
 
         return creative

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -130,6 +130,9 @@ describe 'VASTParser', ->
                     it 'should have 1 companion clickthrough url', =>
                         companion.companionClickThroughURLTemplate.should.equal  'http://example.com/companion-clickthrough'
 
+                    it 'should have 1 companion clicktracking url', =>
+                        companion.companionClickTrackingURLTemplate.should.equal  'http://example.com/companion-clicktracking'
+
                 describe 'as IFrameResource', ->
                   before (done) =>
                       companion = companions.variations[1]

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -41,6 +41,7 @@
                 <Tracking event="creativeView"><![CDATA[http://example.com/creativeview]]></Tracking>
               </TrackingEvents>
               <CompanionClickThrough><![CDATA[http://example.com/companion-clickthrough]]></CompanionClickThrough>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking]]></CompanionClickTracking>
             </Companion>
             <Companion width="300" height="60">
               <IFrameResource>


### PR DESCRIPTION
When parsing companion ads, the VAST parser currently does not
load the optional CompanionClickTracking parameter. The value of
this parameter is required when implementing click tracking, so it
is worth including it in the parser's output. I added a line to read
the value of this parameter and return it in the companion ad object
