### PR TITLE
Added support for multiple companion click tracking properties

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -340,6 +340,7 @@ class VASTParser
             companionAd.id = companionResource.getAttribute("id") or null
             companionAd.width = companionResource.getAttribute("width")
             companionAd.height = companionResource.getAttribute("height")
+            companionAd.companionClickTrackingURLTemplates = []
             for htmlElement in @childsByName(companionResource, "HTMLResource")
                 companionAd.type = htmlElement.getAttribute("creativeType") or 'text/html'
                 companionAd.htmlResource = @parseNodeText(htmlElement)
@@ -356,8 +357,10 @@ class VASTParser
                     if eventName? and trackingURLTemplate?
                         companionAd.trackingEvents[eventName] ?= []
                         companionAd.trackingEvents[eventName].push trackingURLTemplate
+            for clickTrackingElement in @childsByName(companionResource, "CompanionClickTracking")
+              companionAd.companionClickTrackingURLTemplates.push @parseNodeText(clickTrackingElement)
             companionAd.companionClickThroughURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickThrough"))
-            companionAd.companionClickTrackingURLTemplate = @parseNodeText(@childByName(companionResource, "CompanionClickTracking"))
+
             creative.variations.push companionAd
 
         return creative

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -130,8 +130,9 @@ describe 'VASTParser', ->
                     it 'should have 1 companion clickthrough url', =>
                         companion.companionClickThroughURLTemplate.should.equal  'http://example.com/companion-clickthrough'
 
-                    it 'should have 1 companion clicktracking url', =>
-                        companion.companionClickTrackingURLTemplate.should.equal  'http://example.com/companion-clicktracking'
+                    it 'should have 2 companion clicktracking urls', =>
+                        companion.companionClickTrackingURLTemplates[0].should.equal  'http://example.com/companion-clicktracking-first'
+                        companion.companionClickTrackingURLTemplates[1].should.equal  'http://example.com/companion-clicktracking-second'
 
                 describe 'as IFrameResource', ->
                   before (done) =>

--- a/test/sample.xml
+++ b/test/sample.xml
@@ -41,7 +41,8 @@
                 <Tracking event="creativeView"><![CDATA[http://example.com/creativeview]]></Tracking>
               </TrackingEvents>
               <CompanionClickThrough><![CDATA[http://example.com/companion-clickthrough]]></CompanionClickThrough>
-              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking]]></CompanionClickTracking>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking-first]]></CompanionClickTracking>
+              <CompanionClickTracking><![CDATA[http://example.com/companion-clicktracking-second]]></CompanionClickTracking>
             </Companion>
             <Companion width="300" height="60">
               <IFrameResource>


### PR DESCRIPTION
Companion creatives can have multiple CompanionClickTracking
properties and the previous code would simply take the first one
whilst ignoring the others. This change ensures that the tracking urls
are all made available as an array instead.
