### PR TITLE
Update lib to send vast error track

### DIFF
--- a/src/parser.coffee
+++ b/src/parser.coffee
@@ -30,7 +30,7 @@ class VASTParser
 
     @vent = new EventEmitter()
     @track: (templates, errorCode) ->
-        @vent.emit 'VAST-error', errorCode
+        @vent.emit 'VAST-error', templates, errorCode
 
     @on: (eventName, cb) ->
         @vent.on eventName, cb

--- a/test/parser.coffee
+++ b/test/parser.coffee
@@ -183,9 +183,11 @@ describe 'VASTParser', ->
     describe '#track', ->
         errorCallbackCalled = 0
         errorCode = null
-        errorCallback = (ec) ->
+        errorURLTemplates = null
+        errorCallback = (templates, ec) ->
             errorCallbackCalled++
             errorCode = ec
+            errorURLTemplates = templates
 
         beforeEach =>
             VASTParser.vent.removeAllListeners()
@@ -197,6 +199,7 @@ describe 'VASTParser', ->
             VASTParser.parse urlfor('empty.xml'), =>
                 errorCallbackCalled.should.equal 1
                 errorCode.ERRORCODE.should.eql 303
+                errorURLTemplates.should.eql []
                 done()
 
         #No ads VAST response after more than one wrapper

--- a/vast-client.js
+++ b/vast-client.js
@@ -622,7 +622,7 @@ VASTParser = (function() {
   VASTParser.vent = new EventEmitter();
 
   VASTParser.track = function(templates, errorCode) {
-    return this.vent.emit('VAST-error', errorCode);
+    return this.vent.emit('VAST-error', templates, errorCode);
   };
 
   VASTParser.on = function(eventName, cb) {
@@ -1062,7 +1062,7 @@ VASTParser = (function() {
   };
 
   VASTParser.parseCompanionAd = function(creativeElement) {
-    var companionAd, companionResource, creative, eventName, htmlElement, iframeElement, staticElement, trackingElement, trackingEventsElement, trackingURLTemplate, _base, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _len5, _m, _n, _ref, _ref1, _ref2, _ref3, _ref4, _ref5;
+    var clickTrackingElement, companionAd, companionResource, creative, eventName, htmlElement, iframeElement, staticElement, trackingElement, trackingEventsElement, trackingURLTemplate, _base, _i, _j, _k, _l, _len, _len1, _len2, _len3, _len4, _len5, _len6, _m, _n, _o, _ref, _ref1, _ref2, _ref3, _ref4, _ref5, _ref6;
     creative = new VASTCreativeCompanion();
     _ref = this.childsByName(creativeElement, "Companion");
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
@@ -1071,6 +1071,7 @@ VASTParser = (function() {
       companionAd.id = companionResource.getAttribute("id") || null;
       companionAd.width = companionResource.getAttribute("width");
       companionAd.height = companionResource.getAttribute("height");
+      companionAd.companionClickTrackingURLTemplates = [];
       _ref1 = this.childsByName(companionResource, "HTMLResource");
       for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
         htmlElement = _ref1[_j];
@@ -1104,6 +1105,11 @@ VASTParser = (function() {
             companionAd.trackingEvents[eventName].push(trackingURLTemplate);
           }
         }
+      }
+      _ref6 = this.childsByName(companionResource, "CompanionClickTracking");
+      for (_o = 0, _len6 = _ref6.length; _o < _len6; _o++) {
+        clickTrackingElement = _ref6[_o];
+        companionAd.companionClickTrackingURLTemplates.push(this.parseNodeText(clickTrackingElement));
       }
       companionAd.companionClickThroughURLTemplate = this.parseNodeText(this.childByName(companionResource, "CompanionClickThrough"));
       creative.variations.push(companionAd);


### PR DESCRIPTION
The RTB team needs to send VAST error tracks when there is a VAST
error. The vast client lib didn’t support that, so they had to add that
manually in the compiled file. It was a quick solution for a problem.
However the library itself is not the one in mbe-client, but a fork we
have. So any changes in mbe-client should be also implemented in the
fork. Because of that we had to put those changes in the original
coffee file and generate a new compiled file. Thus both mbe-client and
vast-client have the same code.

https://github.com/SponsorPay/mbe-client/pull/393
