### PR TITLE
Update node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "repository": {"type": "git", "url": "https://github.com/dailymotion/vast-client-js"},
     "licenses": [{"type": "MIT", "url": "https://github.com/dailymotion/vast-client-js/raw/master/LICENSE"}],
     "engines": {
-        "node": "0.10.26"
+        "node": ">=0.10.26"
     },
     "main": "dist/index.js",
     "scripts":


### PR DESCRIPTION
The project is using an old node version. So when we tried to import it
as an external dependency from `mbe-client` it complained about module
incompatibility.